### PR TITLE
Add solution for late-init dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ Create `Module` (recommend to use `object`) and extends from `Leviathan` class
 
 Create fields using these functions:
 
-- Use `by instanceOf(keepAlive){/**/}` to create instance dependency
+- Use `by instanceOf(keepAlive){ value }` to create instance dependency
   - `keepAlive = true` : instance persists across different scopes
   - `keepAlive = false`(default): instance is auto-closed when all scopes close
 - Use `by factoryOf(useCache)` to create factory dependency
   - `useCache = true` (default): caches instances within the same scope
   - `useCache = false`: creates new instance on each access
-- Use `by valueOf(value)` to create value dependency (returns the same value always)
+- Use `by valueOf(value)` to create value dependency (the value may be updated later)
+- Use `by providableOf { value }` to create a providable dependency (provider may be updated later)
 
 All functions return a `Dependency<Type>` instance.
 
@@ -78,6 +79,7 @@ object Module : Leviathan() {
     }
     val interfaceRepo by instanceOf<SampleInterfaceRepo> { SampleInterfaceRepoImpl() }
     val constantValue by valueOf(42)
+    val providable by providableOf { 34 }
 }
 ```
 
@@ -107,6 +109,8 @@ fun ComposeWithDI() {
 fun foo() {
     val scope = DIScope()
     val repo1 = Module.autoCloseRepository.injectedIn(scope)
+    // update providable value
+    (Module.providable as? ProvidableDependency<Int>)?.provides { 21 }
     /*..*/
     scope.close()
 }

--- a/gradle/leviathan.toml
+++ b/gradle/leviathan.toml
@@ -1,2 +1,2 @@
 [versions]
-leviathan = "3.0.1"
+leviathan = "3.1.0"

--- a/gradle/leviathan.toml
+++ b/gradle/leviathan.toml
@@ -1,2 +1,2 @@
 [versions]
-leviathan = "3.0.0"
+leviathan = "3.0.1"

--- a/leviathan/api/android/leviathan.api
+++ b/leviathan/api/android/leviathan.api
@@ -16,6 +16,14 @@ public final class com/composegears/leviathan/DependencyInitializationScope {
 	public final fun inject (Lcom/composegears/leviathan/Dependency;)Ljava/lang/Object;
 }
 
+public final class com/composegears/leviathan/FactoryDependency : com/composegears/leviathan/Dependency {
+	public fun injectedIn (Lcom/composegears/leviathan/DIScope;)Ljava/lang/Object;
+}
+
+public final class com/composegears/leviathan/InstanceDependency : com/composegears/leviathan/Dependency {
+	public fun injectedIn (Lcom/composegears/leviathan/DIScope;)Ljava/lang/Object;
+}
+
 public abstract class com/composegears/leviathan/Leviathan {
 	public static final field Companion Lcom/composegears/leviathan/Leviathan$Companion;
 	public fun <init> ()V
@@ -24,14 +32,20 @@ public abstract class com/composegears/leviathan/Leviathan {
 	protected static final fun getValue (Lcom/composegears/leviathan/Dependency;Lcom/composegears/leviathan/Leviathan;Lkotlin/reflect/KProperty;)Lcom/composegears/leviathan/Dependency;
 	protected final fun instanceOf (ZLkotlin/jvm/functions/Function1;)Lcom/composegears/leviathan/Dependency;
 	public static synthetic fun instanceOf$default (Lcom/composegears/leviathan/Leviathan;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/composegears/leviathan/Dependency;
+	protected final fun providableOf (Lkotlin/jvm/functions/Function0;)Lcom/composegears/leviathan/ProvidableDependency;
 	protected final fun valueOf (Ljava/lang/Object;)Lcom/composegears/leviathan/Dependency;
 }
 
 public final class com/composegears/leviathan/Leviathan$Companion {
 }
 
-public final class com/composegears/leviathan/ValueDependency : com/composegears/leviathan/Dependency {
-	public fun <init> (Ljava/lang/Object;)V
+public final class com/composegears/leviathan/ProvidableDependency : com/composegears/leviathan/Dependency {
 	public fun injectedIn (Lcom/composegears/leviathan/DIScope;)Ljava/lang/Object;
+	public final fun provides (Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class com/composegears/leviathan/ValueDependency : com/composegears/leviathan/Dependency {
+	public fun injectedIn (Lcom/composegears/leviathan/DIScope;)Ljava/lang/Object;
+	public final fun provides (Ljava/lang/Object;)V
 }
 

--- a/leviathan/api/jvm/leviathan.api
+++ b/leviathan/api/jvm/leviathan.api
@@ -16,6 +16,14 @@ public final class com/composegears/leviathan/DependencyInitializationScope {
 	public final fun inject (Lcom/composegears/leviathan/Dependency;)Ljava/lang/Object;
 }
 
+public final class com/composegears/leviathan/FactoryDependency : com/composegears/leviathan/Dependency {
+	public fun injectedIn (Lcom/composegears/leviathan/DIScope;)Ljava/lang/Object;
+}
+
+public final class com/composegears/leviathan/InstanceDependency : com/composegears/leviathan/Dependency {
+	public fun injectedIn (Lcom/composegears/leviathan/DIScope;)Ljava/lang/Object;
+}
+
 public abstract class com/composegears/leviathan/Leviathan {
 	public static final field Companion Lcom/composegears/leviathan/Leviathan$Companion;
 	public fun <init> ()V
@@ -24,14 +32,20 @@ public abstract class com/composegears/leviathan/Leviathan {
 	protected static final fun getValue (Lcom/composegears/leviathan/Dependency;Lcom/composegears/leviathan/Leviathan;Lkotlin/reflect/KProperty;)Lcom/composegears/leviathan/Dependency;
 	protected final fun instanceOf (ZLkotlin/jvm/functions/Function1;)Lcom/composegears/leviathan/Dependency;
 	public static synthetic fun instanceOf$default (Lcom/composegears/leviathan/Leviathan;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/composegears/leviathan/Dependency;
+	protected final fun providableOf (Lkotlin/jvm/functions/Function0;)Lcom/composegears/leviathan/ProvidableDependency;
 	protected final fun valueOf (Ljava/lang/Object;)Lcom/composegears/leviathan/Dependency;
 }
 
 public final class com/composegears/leviathan/Leviathan$Companion {
 }
 
-public final class com/composegears/leviathan/ValueDependency : com/composegears/leviathan/Dependency {
-	public fun <init> (Ljava/lang/Object;)V
+public final class com/composegears/leviathan/ProvidableDependency : com/composegears/leviathan/Dependency {
 	public fun injectedIn (Lcom/composegears/leviathan/DIScope;)Ljava/lang/Object;
+	public final fun provides (Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class com/composegears/leviathan/ValueDependency : com/composegears/leviathan/Dependency {
+	public fun injectedIn (Lcom/composegears/leviathan/DIScope;)Ljava/lang/Object;
+	public final fun provides (Ljava/lang/Object;)V
 }
 

--- a/leviathan/api/leviathan.klib.api
+++ b/leviathan/api/leviathan.klib.api
@@ -15,15 +15,28 @@ abstract class com.composegears.leviathan/Leviathan { // com.composegears.leviat
 
     final fun <#A1: kotlin/Any?> factoryOf(kotlin/Boolean = ..., kotlin/Function1<com.composegears.leviathan/DependencyInitializationScope, #A1>): com.composegears.leviathan/Dependency<#A1> // com.composegears.leviathan/Leviathan.factoryOf|factoryOf(kotlin.Boolean;kotlin.Function1<com.composegears.leviathan.DependencyInitializationScope,0:0>){0§<kotlin.Any?>}[0]
     final fun <#A1: kotlin/Any?> instanceOf(kotlin/Boolean = ..., kotlin/Function1<com.composegears.leviathan/DependencyInitializationScope, #A1>): com.composegears.leviathan/Dependency<#A1> // com.composegears.leviathan/Leviathan.instanceOf|instanceOf(kotlin.Boolean;kotlin.Function1<com.composegears.leviathan.DependencyInitializationScope,0:0>){0§<kotlin.Any?>}[0]
+    final fun <#A1: kotlin/Any?> providableOf(kotlin/Function0<#A1>): com.composegears.leviathan/ProvidableDependency<#A1> // com.composegears.leviathan/Leviathan.providableOf|providableOf(kotlin.Function0<0:0>){0§<kotlin.Any?>}[0]
     final fun <#A1: kotlin/Any?> valueOf(#A1): com.composegears.leviathan/Dependency<#A1> // com.composegears.leviathan/Leviathan.valueOf|valueOf(0:0){0§<kotlin.Any?>}[0]
 
     final object Companion // com.composegears.leviathan/Leviathan.Companion|null[0]
 }
 
-final class <#A: kotlin/Any?> com.composegears.leviathan/ValueDependency : com.composegears.leviathan/Dependency<#A> { // com.composegears.leviathan/ValueDependency|null[0]
-    constructor <init>(#A) // com.composegears.leviathan/ValueDependency.<init>|<init>(1:0){}[0]
+final class <#A: kotlin/Any?> com.composegears.leviathan/FactoryDependency : com.composegears.leviathan/Dependency<#A> { // com.composegears.leviathan/FactoryDependency|null[0]
+    final fun injectedIn(com.composegears.leviathan/DIScope): #A // com.composegears.leviathan/FactoryDependency.injectedIn|injectedIn(com.composegears.leviathan.DIScope){}[0]
+}
 
+final class <#A: kotlin/Any?> com.composegears.leviathan/InstanceDependency : com.composegears.leviathan/Dependency<#A> { // com.composegears.leviathan/InstanceDependency|null[0]
+    final fun injectedIn(com.composegears.leviathan/DIScope): #A // com.composegears.leviathan/InstanceDependency.injectedIn|injectedIn(com.composegears.leviathan.DIScope){}[0]
+}
+
+final class <#A: kotlin/Any?> com.composegears.leviathan/ProvidableDependency : com.composegears.leviathan/Dependency<#A> { // com.composegears.leviathan/ProvidableDependency|null[0]
+    final fun injectedIn(com.composegears.leviathan/DIScope): #A // com.composegears.leviathan/ProvidableDependency.injectedIn|injectedIn(com.composegears.leviathan.DIScope){}[0]
+    final fun provides(kotlin/Function0<#A>) // com.composegears.leviathan/ProvidableDependency.provides|provides(kotlin.Function0<1:0>){}[0]
+}
+
+final class <#A: kotlin/Any?> com.composegears.leviathan/ValueDependency : com.composegears.leviathan/Dependency<#A> { // com.composegears.leviathan/ValueDependency|null[0]
     final fun injectedIn(com.composegears.leviathan/DIScope): #A // com.composegears.leviathan/ValueDependency.injectedIn|injectedIn(com.composegears.leviathan.DIScope){}[0]
+    final fun provides(#A) // com.composegears.leviathan/ValueDependency.provides|provides(1:0){}[0]
 }
 
 final class com.composegears.leviathan/DependencyInitializationScope { // com.composegears.leviathan/DependencyInitializationScope|null[0]


### PR DESCRIPTION
Resolves #22 
- Add late initialization providers: FactoryDependency
- Add option to update ValueDependency's value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced providable dependencies that can update their provider at runtime.
  * Value-based dependencies can now update their value after creation.
  * Factory and instance dependencies are now publicly available.
* Documentation
  * Updated examples and guidance to reflect new dependency semantics and usage, including providable and updatable value patterns.
* Tests
  * Added tests covering consistent value provision, value updates, and provider updates for providable dependencies.
* Chores
  * Bumped Leviathan dependency version from 3.0.0 to 3.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->